### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,74 +155,56 @@ jobs:
 
   # Release Job
   release:
-    name: Create Release
+    name: Release
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'push' && 
-       (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') &&
+      (github.event_name == 'push' &&
        !contains(github.event.head_commit.message, '[skip ci]')) ||
       (github.event_name == 'workflow_dispatch')
-    needs: [python-format-check, flake-check, tests]
     permissions:
-      contents: write
+      contents: write  # To push tags
       issues: write
       pull-requests: write
-      packages: write
       id-token: write
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      release_tag: ${{ steps.release.outputs.tag_name }}
-      release_version: ${{ steps.release.outputs.version }}
+      git_short_sha: ${{ steps.capture_tag.outputs.git_short_sha }}
+      release_tag: ${{ steps.capture_tag.outputs.release_tag }}
+      image_tag: ${{ steps.capture_tag.outputs.image_tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
         with:
-          python-version: '3.11'
+          node-version: '20'
 
-      - name: Install build dependencies
+      - name: Install Semantic Release and Plugins
         run: |
-          python -m pip install --upgrade pip
-          pip install build setuptools wheel twine
+          npm install -g semantic-release@21.0.2 @semantic-release/gitlab @semantic-release/exec @semantic-release/changelog @semantic-release/release-notes-generator @semantic-release/commit-analyzer @semantic-release/git
 
-      - name: Create Release with Release Please
-        uses: google-github-actions/release-please-action@v4
-        id: release
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: python
-          package-name: employee-simulation-system
-          
-      - name: Build Python package
-        if: steps.release.outputs.release_created
-        run: |
-          python -m build
-          
-      - name: Upload Release Assets
-        if: steps.release.outputs.release_created
+      - name: Fetch all tags
+        run: git fetch --tags
+
+      - name: Run Semantic Release
+        id: semantic_release
+        run: semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+
+      - name: Capture New Tag and Set Image Tag
+        id: capture_tag
         run: |
-          # Upload distribution files to the release
-          gh release upload ${{ steps.release.outputs.tag_name }} dist/* --clobber
-          
-      - name: Generate Release Summary
-        if: steps.release.outputs.release_created
-        run: |
-          echo "## 🎉 Release Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ steps.release.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** ${{ steps.release.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📦 Assets Built" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- Python wheel (`.whl`)" >> $GITHUB_STEP_SUMMARY  
-          echo "- Source distribution (`.tar.gz`)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 🔗 Release Link" >> $GITHUB_STEP_SUMMARY
-          echo "[View Release](https://github.com/${{ github.repository }}/releases/tag/${{ steps.release.outputs.tag_name }})" >> $GITHUB_STEP_SUMMARY
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            RELEASE_TAG=${GITHUB_REF#refs/tags/}
+            IMAGE_TAG=${RELEASE_TAG}
+          else
+            RELEASE_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+            GIT_SHORT_SHA=$(git rev-parse --short HEAD)
+            IMAGE_TAG=latest-${GIT_SHORT_SHA}
+          fi
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
+          echo "GIT_SHORT_SHA=${GIT_SHORT_SHA:-}" >> $GITHUB_ENV
+          echo "release_tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
+          echo "git_short_sha=${GIT_SHORT_SHA:-}" >> $GITHUB_OUTPUT
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary by Sourcery

Migrate the release workflow from a Python-based Release Please process to a Node.js semantic-release pipeline, updating steps, triggers, permissions, and job outputs accordingly.

Enhancements:
- Simplify workflow triggers and remove previous job dependencies
- Adjust permissions for tag pushing and refine job outputs for release metadata

CI:
- Migrate release job to semantic-release on Node.js, replacing Release Please
- Switch actions/setup-python to actions/setup-node@v3 with Node 20 and install semantic-release plugins
- Update checkout action to actions/checkout@v3, fetch tags, and run semantic-release
- Capture git_short_sha, release_tag, and image_tag from git refs and expose them as job outputs